### PR TITLE
chore: add CODEOWNERS for tier0 repo compliance

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @doctolib/sre @doctolib/platform-security


### PR DESCRIPTION
## Summary

This tier0 public repo had no CODEOWNERS file. Without it, `require_code_owner_reviews` in branch protection silently passes for all files (GitHub auto-approves when no owner is defined), making the setting a no-op.

## Change

Adds `.github/CODEOWNERS` assigning `@doctolib/sre` and `@doctolib/platform-security` as required reviewers for all files.

## Security context

This repo publishes a Terraform provider binary signed with a GPG key loaded from Vault via OIDC in the release workflow. A merged malicious PR could exfiltrate the signing key and enable a supply chain attack on the provider.

Companion PR: https://github.com/doctolib/github-workspaces/pull/5663